### PR TITLE
Remove optimistic update actions

### DIFF
--- a/src/action-types.js
+++ b/src/action-types.js
@@ -5,6 +5,3 @@ export const stopEditingRef = (entityGroup = 'entities', entityName, id) => `STO
 export const BEGIN_EDITING = 'BEGIN_EDITING';
 export const UPDATE_EDITABLE = 'UPDATE_EDITABLE';
 export const STOP_EDITING = 'STOP_EDITING';
-
-export const OPTIMISTIC_UPDATE = (entityGroup = 'entities') => `OPTIMISTIC_UPDATE/${entityGroup}`;
-export const RESOLVE_OPTIMISTIC_UPDATE = (entityGroup = 'entities') => `RESOLVE_OPTIMISTIC_UPDATE/${entityGroup}`;

--- a/src/actions.js
+++ b/src/actions.js
@@ -5,9 +5,7 @@ import {
   stopEditingRef,
   BEGIN_EDITING,
   UPDATE_EDITABLE,
-  STOP_EDITING,
-  OPTIMISTIC_UPDATE,
-  RESOLVE_OPTIMISTIC_UPDATE
+  STOP_EDITING
 } from './action-types';
 
 /**
@@ -43,18 +41,3 @@ export const createEditActions = (entityGroup, entityName) => Object.keys(editAc
     [actionName]: (...params) => editActions[actionName](entityGroup, entityName, ...params)
   }), {}
 );
-
-export const optimisticUpdate = (entityGroup, ref, optimisticEntities) => ({
-  type: OPTIMISTIC_UPDATE(entityGroup),
-  payload: {
-    ref,
-    optimisticEntities
-  }
-});
-
-export const resolveOptimisticUpdate = (entityGroup, ref) => ({
-  type: RESOLVE_OPTIMISTIC_UPDATE(entityGroup),
-  payload: {
-    ref
-  }
-});


### PR DESCRIPTION
### Description
Optimistic updates have been removed from this repo, since it relies on things from https://github.com/zendesk/redux-api-status
This code was left over and should be removed.